### PR TITLE
fix: properly validate supported currencies

### DIFF
--- a/CURRENCY_SELECTOR_TEST.md
+++ b/CURRENCY_SELECTOR_TEST.md
@@ -113,6 +113,7 @@ This document outlines the manual testing steps for the currency selector featur
 ## Notes
 - Test with both USD and IDR currencies
 - Verify exchange rate calculations
+- `isSupportedCurrency` only accepts defined currency codes and rejects prototype properties
 - Check for any console errors
 - Ensure responsive design works on different screen sizes
 

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -131,7 +131,12 @@ export function getSupportedCurrencies(): SupportedCurrency[] {
  * Check if a currency is supported
  */
 export function isSupportedCurrency(currency: string): currency is SupportedCurrency {
-	return currency in CURRENCY_CONFIGS
+        // Using the `in` operator here would return true for any property
+        // on the object's prototype chain (e.g. `toString`), which means
+        // invalid currency strings could be treated as supported. Use
+        // `hasOwnProperty` to ensure only explicitly defined currencies are
+        // considered valid.
+        return Object.prototype.hasOwnProperty.call(CURRENCY_CONFIGS, currency)
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard against prototype pollution by using own-property check in currency validation
- exercise currency utilities and ensure `isSupportedCurrency` rejects prototype properties
- document that `isSupportedCurrency` rejects prototype properties

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `node test-currency-selector.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68a821a49c9083209f7617782bbf15df