### PR TITLE
Statistics: shared analytics period (Approach B), trends, a11y, i18n nav

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,6 +4,7 @@
 // Updated to use LimelightNav component with green accent color
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Home, CreditCard, Wallet, BarChart3, PieChart, User } from 'lucide-react';
 import { LimelightNav, NavItem } from '@/components/ui/limelight-nav';
@@ -46,16 +47,17 @@ const navContentVariants = {
 };
 
 const Navbar: React.FC = () => {
+  const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
 
   const navItems: NavItem[] = [
-    { id: 'home', icon: <Home />, label: 'Home', onClick: () => navigate('/') },
-    { id: 'transactions', icon: <CreditCard />, label: 'Transactions', onClick: () => navigate('/transactions') },
-    { id: 'wallets', icon: <Wallet />, label: 'Wallets', onClick: () => navigate('/wallets') },
-    { id: 'statistics', icon: <BarChart3 />, label: 'Statistics', onClick: () => navigate('/statistics') },
-    { id: 'budget', icon: <PieChart />, label: 'Budget', onClick: () => navigate('/budget') },
-    { id: 'profile', icon: <User />, label: 'Profile', onClick: () => navigate('/profile') },
+    { id: 'home', icon: <Home />, label: t('navbar.home'), onClick: () => navigate('/') },
+    { id: 'transactions', icon: <CreditCard />, label: t('navbar.transactions'), onClick: () => navigate('/transactions') },
+    { id: 'wallets', icon: <Wallet />, label: t('navbar.wallets'), onClick: () => navigate('/wallets') },
+    { id: 'statistics', icon: <BarChart3 />, label: t('navbar.statistics'), onClick: () => navigate('/statistics') },
+    { id: 'budget', icon: <PieChart />, label: t('navbar.budget'), onClick: () => navigate('/budget') },
+    { id: 'profile', icon: <User />, label: t('navbar.profile'), onClick: () => navigate('/profile') },
   ];
 
   const pathToIndex = {

--- a/src/context/AnalyticsPeriodContext.tsx
+++ b/src/context/AnalyticsPeriodContext.tsx
@@ -1,0 +1,96 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  computeAnalyticsBounds,
+  type AnalyticsDatePreset,
+} from '@/context/analyticsPeriodUtils'
+
+export type { AnalyticsDatePreset }
+
+interface AnalyticsPeriodContextValue {
+  preset: AnalyticsDatePreset
+  setPreset: (p: AnalyticsDatePreset) => void
+  customStartDate: Date | undefined
+  customEndDate: Date | undefined
+  setCustomRange: (from: Date | undefined, to: Date | undefined) => void
+  periodStart: Date
+  periodEnd: Date
+  setPeriodFromAnalysis: (start: Date, end: Date) => void
+}
+
+const AnalyticsPeriodContext = createContext<AnalyticsPeriodContextValue | undefined>(
+  undefined,
+)
+
+export function AnalyticsPeriodProvider({ children }: { children: ReactNode }) {
+  const [preset, setPresetState] = useState<AnalyticsDatePreset>('month')
+  const [customStartDate, setCustomStartDate] = useState<Date | undefined>(undefined)
+  const [customEndDate, setCustomEndDate] = useState<Date | undefined>(undefined)
+
+  const { periodStart, periodEnd } = useMemo(
+    () => computeAnalyticsBounds(preset, customStartDate, customEndDate),
+    [preset, customStartDate, customEndDate],
+  )
+
+  const setPreset = useCallback((p: AnalyticsDatePreset) => {
+    setPresetState(p)
+  }, [])
+
+  const setCustomRange = useCallback((from: Date | undefined, to: Date | undefined) => {
+    setCustomStartDate(from)
+    setCustomEndDate(to)
+  }, [])
+
+  const setPeriodFromAnalysis = useCallback((start: Date, end: Date) => {
+    setPresetState('custom')
+    setCustomStartDate(start)
+    setCustomEndDate(end)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      preset,
+      setPreset,
+      customStartDate,
+      customEndDate,
+      setCustomRange,
+      periodStart,
+      periodEnd,
+      setPeriodFromAnalysis,
+    }),
+    [
+      preset,
+      setPreset,
+      customStartDate,
+      customEndDate,
+      setCustomRange,
+      periodStart,
+      periodEnd,
+      setPeriodFromAnalysis,
+    ],
+  )
+
+  return (
+    <AnalyticsPeriodContext.Provider value={value}>
+      {children}
+    </AnalyticsPeriodContext.Provider>
+  )
+}
+
+export function useAnalyticsPeriod() {
+  const ctx = useContext(AnalyticsPeriodContext)
+  if (!ctx) {
+    throw new Error('useAnalyticsPeriod must be used within AnalyticsPeriodProvider')
+  }
+  return ctx
+}
+
+export function useOptionalAnalyticsPeriod() {
+  return useContext(AnalyticsPeriodContext)
+}

--- a/src/context/analyticsPeriodUtils.ts
+++ b/src/context/analyticsPeriodUtils.ts
@@ -1,0 +1,37 @@
+export type AnalyticsDatePreset = '7days' | '30days' | 'month' | 'custom'
+
+export function computeAnalyticsBounds(
+  preset: AnalyticsDatePreset,
+  customStart: Date | undefined,
+  customEnd: Date | undefined,
+  referenceNow = new Date(),
+): { start: Date; end: Date } {
+  const endOfToday = new Date(referenceNow)
+  endOfToday.setHours(23, 59, 59, 999)
+
+  if (preset === 'custom' && customStart && customEnd) {
+    const start = new Date(customStart)
+    start.setHours(0, 0, 0, 0)
+    const end = new Date(customEnd)
+    end.setHours(23, 59, 59, 999)
+    return { start, end }
+  }
+
+  if (preset === '7days') {
+    const start = new Date(referenceNow)
+    start.setDate(start.getDate() - 7)
+    start.setHours(0, 0, 0, 0)
+    return { start, end: endOfToday }
+  }
+
+  if (preset === '30days') {
+    const start = new Date(referenceNow)
+    start.setDate(start.getDate() - 30)
+    start.setHours(0, 0, 0, 0)
+    return { start, end: endOfToday }
+  }
+
+  const start = new Date(referenceNow.getFullYear(), referenceNow.getMonth(), 1)
+  start.setHours(0, 0, 0, 0)
+  return { start, end: endOfToday }
+}

--- a/src/features/ai-evaluator/EvaluateContent.tsx
+++ b/src/features/ai-evaluator/EvaluateContent.tsx
@@ -2,38 +2,67 @@
 // Description: AI Financial Evaluator content without header - designed to be embedded in Statistics page
 // This is a modified version of EvaluatePage that removes the header and navigation for tabbed integration
 
-import React, { useState, useEffect } from 'react';
-import { useFinance } from '@/context/FinanceContext';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { DatePicker } from '@/components/ui/date-picker';
-import { Calendar, TrendingUp, BarChart3, PieChart, DollarSign } from 'lucide-react';
-import { motion } from 'framer-motion';
-import { getFinanceInsight } from './api';
-import { InsightDisplay } from './InsightDisplay';
-import { SuggestedQuestions } from './SuggestedQuestions';
-import { ChatBox } from './ChatBox';
-import type { FinanceSummary, ChatMessage } from '@/types/finance';
-import { useTranslation } from 'react-i18next';
-import { useCategories } from '@/hooks/useCategories';
+import React, { useLayoutEffect, useState } from 'react'
+import { useFinance } from '@/context/FinanceContext'
+import { useOptionalAnalyticsPeriod } from '@/context/AnalyticsPeriodContext'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { DatePicker } from '@/components/ui/date-picker'
+import { Calendar, TrendingUp, BarChart3, PieChart, DollarSign } from 'lucide-react'
+import { motion } from 'framer-motion'
+import { getFinanceInsight } from './api'
+import { InsightDisplay } from './InsightDisplay'
+import { SuggestedQuestions } from './SuggestedQuestions'
+import { ChatBox } from './ChatBox'
+import type { FinanceSummary, ChatMessage } from '@/types/finance'
+import { useTranslation } from 'react-i18next'
+import { useCategories } from '@/hooks/useCategories'
 
 const EvaluateContent: React.FC = () => {
-  const { transactions, wallets } = useFinance();
-  const { findById, getDisplayName } = useCategories();
-  const { t, i18n } = useTranslation();
-  
-  const [startDate, setStartDate] = useState<Date | undefined>(
-    new Date(new Date().getFullYear(), new Date().getMonth(), 1)
-  );
-  const [endDate, setEndDate] = useState<Date | undefined>(new Date());
-  const [insight, setInsight] = useState<string>('');
-  const [currentSummary, setCurrentSummary] = useState<FinanceSummary | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
-  const [selectedQuestion, setSelectedQuestion] = useState<string>('');
+  const { transactions, formatCurrency } = useFinance()
+  const analyticsPeriod = useOptionalAnalyticsPeriod()
+  const { findById, getDisplayName } = useCategories()
+  const { t } = useTranslation()
 
-  // Calculate finance summary
+  const [startDate, setStartDate] = useState<Date | undefined>(undefined)
+  const [endDate, setEndDate] = useState<Date | undefined>(undefined)
+  const [insight, setInsight] = useState<string>('')
+  const [currentSummary, setCurrentSummary] = useState<FinanceSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
+  const [selectedQuestion, setSelectedQuestion] = useState<string>('')
+
+  const periodStartMs = analyticsPeriod?.periodStart.getTime()
+  const periodEndMs = analyticsPeriod?.periodEnd.getTime()
+
+  useLayoutEffect(() => {
+    if (analyticsPeriod) {
+      setStartDate(new Date(analyticsPeriod.periodStart))
+      setEndDate(new Date(analyticsPeriod.periodEnd))
+      return
+    }
+    const today = new Date()
+    setStartDate(new Date(today.getFullYear(), today.getMonth(), 1))
+    setEndDate(today)
+  }, [analyticsPeriod, periodStartMs, periodEndMs])
+
+  const pushPeriodToStatistics = (nextStart: Date | undefined, nextEnd: Date | undefined) => {
+    if (nextStart && nextEnd && analyticsPeriod) {
+      analyticsPeriod.setPeriodFromAnalysis(nextStart, nextEnd)
+    }
+  }
+
+  const setStartDateSynced = (d: Date | undefined) => {
+    setStartDate(d)
+    if (d && endDate) pushPeriodToStatistics(d, endDate)
+  }
+
+  const setEndDateSynced = (d: Date | undefined) => {
+    setEndDate(d)
+    if (startDate && d) pushPeriodToStatistics(startDate, d)
+  }
+
   const calculateSummary = (): FinanceSummary => {
     if (!startDate || !endDate) {
       return {
@@ -44,65 +73,72 @@ const EvaluateContent: React.FC = () => {
         totalIncome: 0,
         totalExpenses: 0,
         netFlow: 0,
-      };
+      }
     }
 
-    const filteredTransactions = transactions.filter(t => {
-      const transactionDate = new Date(t.date);
-      // Normalize dates to avoid timezone issues
+    const filteredTransactions = transactions.filter((tr) => {
+      const transactionDate = new Date(tr.date)
       const normalizeDate = (date: Date) => {
-        return new Date(date.getFullYear(), date.getMonth(), date.getDate());
-      };
+        return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+      }
 
-      const normalizedTransactionDate = normalizeDate(transactionDate);
-      const normalizedStartDate = normalizeDate(startDate);
-      const normalizedEndDate = normalizeDate(endDate);
+      const normalizedTransactionDate = normalizeDate(transactionDate)
+      const normalizedStartDate = normalizeDate(startDate)
+      const normalizedEndDate = normalizeDate(endDate)
 
-      return normalizedTransactionDate >= normalizedStartDate && normalizedTransactionDate <= normalizedEndDate;
-    });
+      return (
+        normalizedTransactionDate >= normalizedStartDate &&
+        normalizedTransactionDate <= normalizedEndDate
+      )
+    })
 
-    // Process income transactions with proper category names
     const income = filteredTransactions
-      .filter(t => t.type === 'income')
-      .reduce((acc, t) => {
-        // Get category display name
-        const category = findById(t.categoryId);
-        const categoryName = category ? getDisplayName(category, i18n.language) : t('income.categories.other', 'Other Income');
-        const existing = acc.find(item => item.category === categoryName);
-        if (existing) {
-          existing.amount += t.amount;
-        } else {
-          acc.push({ category: categoryName, amount: t.amount });
-        }
-        return acc;
-      }, [] as Array<{ category: string; amount: number }>);
+      .filter((tr) => tr.type === 'income')
+      .reduce(
+        (acc, tr) => {
+          const category = findById(tr.categoryId)
+          const categoryName = category
+            ? getDisplayName(category)
+            : t('income.categories.other', 'Other Income')
+          const existing = acc.find((item) => item.category === categoryName)
+          if (existing) {
+            existing.amount += tr.amount
+          } else {
+            acc.push({ category: categoryName, amount: tr.amount })
+          }
+          return acc
+        },
+        [] as Array<{ category: string; amount: number }>,
+      )
 
-    // Process expense transactions with proper category names
     const expenses = filteredTransactions
-      .filter(t => t.type === 'expense')
-      .reduce((acc, t) => {
-        // Get category display name
-        const category = findById(t.categoryId);
-        const categoryName = category ? getDisplayName(category, i18n.language) : t('transactions.categories.other', 'Other Expenses');
-        const existing = acc.find(item => item.category === categoryName);
-        if (existing) {
-          existing.amount += t.amount;
-        } else {
-          acc.push({ category: categoryName, amount: t.amount });
-        }
-        return acc;
-      }, [] as Array<{ category: string; amount: number }>);
+      .filter((tr) => tr.type === 'expense')
+      .reduce(
+        (acc, tr) => {
+          const category = findById(tr.categoryId)
+          const categoryName = category
+            ? getDisplayName(category)
+            : t('transactions.categories.other', 'Other Expenses')
+          const existing = acc.find((item) => item.category === categoryName)
+          if (existing) {
+            existing.amount += tr.amount
+          } else {
+            acc.push({ category: categoryName, amount: tr.amount })
+          }
+          return acc
+        },
+        [] as Array<{ category: string; amount: number }>,
+      )
 
-    const totalIncome = income.reduce((sum, item) => sum + item.amount, 0);
-    const totalExpenses = expenses.reduce((sum, item) => sum + item.amount, 0);
+    const totalIncome = income.reduce((sum, item) => sum + item.amount, 0)
+    const totalExpenses = expenses.reduce((sum, item) => sum + item.amount, 0)
 
-    // Format dates properly to avoid timezone issues
     const formatLocalDate = (date: Date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
 
     return {
       startDate: formatLocalDate(startDate),
@@ -112,129 +148,134 @@ const EvaluateContent: React.FC = () => {
       totalIncome,
       totalExpenses,
       netFlow: totalIncome - totalExpenses,
-    };
-  };
+    }
+  }
 
   const handleEvaluate = async () => {
-    const summary = calculateSummary();
-    
+    const summary = calculateSummary()
+
     if (summary.totalIncome === 0 && summary.totalExpenses === 0) {
-      setInsight(t('ai.noDataMessage', 'No transaction data for the selected period. Please choose another period or add transactions first.'));
-      return;
+      setInsight(
+        t(
+          'ai.noDataMessage',
+          'No transaction data for the selected period. Please choose another period or add transactions first.',
+        ),
+      )
+      return
     }
 
-    setIsLoading(true);
+    setIsLoading(true)
     try {
-      const result = await getFinanceInsight(summary);
-      setInsight(result);
-      setCurrentSummary(summary);
-      // Reset chat messages when new evaluation is done
-      setChatMessages([]);
+      const result = await getFinanceInsight(summary)
+      setInsight(result)
+      setCurrentSummary(summary)
+      setChatMessages([])
     } catch (error) {
-      console.error('Error getting insight:', error);
-      setInsight(t('ai.errorMessage', 'Sorry, an error occurred while analyzing your financial data. Please try again.'));
+      console.error('Error getting insight:', error)
+      setInsight(
+        t(
+          'ai.errorMessage',
+          'Sorry, an error occurred while analyzing your financial data. Please try again.',
+        ),
+      )
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   const handleQuestionSelect = (question: string) => {
-    // Set the selected question to be auto-filled in ChatBox
-    setSelectedQuestion(question);
-  };
+    setSelectedQuestion(question)
+  }
 
   const handleQuestionUsed = () => {
-    // Reset selected question after it's been used
-    setSelectedQuestion('');
-  };
+    setSelectedQuestion('')
+  }
 
-  const summary = calculateSummary();
+  const summary = calculateSummary()
 
-  // Enhanced animation variants for smooth reveal effects
   const containerVariants = {
     hidden: {
-      opacity: 0
+      opacity: 0,
     },
     visible: {
       opacity: 1,
       transition: {
-        type: "spring",
+        type: 'spring' as const,
         stiffness: 300,
         damping: 30,
         staggerChildren: 0.15,
-        delayChildren: 0.1
-      }
-    }
-  };
+        delayChildren: 0.1,
+      },
+    },
+  }
 
   const itemVariants = {
-    hidden: { 
-      y: 30, 
+    hidden: {
+      y: 30,
       opacity: 0,
-      scale: 0.95
+      scale: 0.95,
     },
     visible: {
       y: 0,
       opacity: 1,
       scale: 1,
-      transition: { 
-        type: "spring", 
-        stiffness: 400, 
+      transition: {
+        type: 'spring' as const,
+        stiffness: 400,
         damping: 25,
-        duration: 0.6
-      }
-    }
-  };
+        duration: 0.6,
+      },
+    },
+  }
 
   const statsVariants = {
     hidden: {
       opacity: 0,
-      scale: 0.9
+      scale: 0.9,
     },
     visible: {
       opacity: 1,
       scale: 1,
       transition: {
-        type: "spring",
+        type: 'spring' as const,
         stiffness: 300,
         damping: 20,
-        staggerChildren: 0.1
-      }
-    }
-  };
+        staggerChildren: 0.1,
+      },
+    },
+  }
 
   const cardVariants = {
     hidden: {
       x: -20,
-      opacity: 0
+      opacity: 0,
     },
     visible: {
       x: 0,
       opacity: 1,
       transition: {
-        type: "spring",
+        type: 'spring' as const,
         stiffness: 400,
-        damping: 25
-      }
+        damping: 25,
+      },
     },
     hover: {
       scale: 1.02,
       transition: {
-        type: "spring",
+        type: 'spring' as const,
         stiffness: 400,
-        damping: 10
-      }
-    }
-  };
+        damping: 10,
+      },
+    },
+  }
 
   return (
-    <motion.div 
+    <motion.div
       className="space-y-6 px-6"
       initial="hidden"
       animate="visible"
       variants={containerVariants}
     >
-      {/* Date Selection */}
       <motion.div variants={itemVariants}>
         <Card className="border bg-card">
           <CardHeader>
@@ -247,19 +288,11 @@ const EvaluateContent: React.FC = () => {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
               <div className="space-y-2">
                 <Label className="text-gray-300">{t('common.startDate', 'Start Date')}</Label>
-                <DatePicker
-                  date={startDate}
-                  setDate={setStartDate}
-                  className="w-full"
-                />
+                <DatePicker date={startDate} setDate={setStartDateSynced} className="w-full" />
               </div>
               <div className="space-y-2">
                 <Label className="text-gray-300">{t('common.endDate', 'End Date')}</Label>
-                <DatePicker
-                  date={endDate}
-                  setDate={setEndDate}
-                  className="w-full"
-                />
+                <DatePicker date={endDate} setDate={setEndDateSynced} className="w-full" />
               </div>
             </div>
 
@@ -274,10 +307,9 @@ const EvaluateContent: React.FC = () => {
         </Card>
       </motion.div>
 
-      {/* Quick Stats */}
       {(summary.totalIncome > 0 || summary.totalExpenses > 0) && (
-        <motion.div 
-          className="space-y-3 w-full" 
+        <motion.div
+          className="space-y-3 w-full"
           variants={statsVariants}
           initial="hidden"
           animate="visible"
@@ -288,10 +320,12 @@ const EvaluateContent: React.FC = () => {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <TrendingUp className="w-4 h-4 text-green-500 flex-shrink-0" />
-                    <span className="text-sm text-gray-400">{t('transactions.income', 'Income')}</span>
+                    <span className="text-sm text-gray-400">
+                      {t('transactions.income', 'Income')}
+                    </span>
                   </div>
                   <p className="text-base font-bold text-green-500">
-                    Rp{summary.totalIncome.toLocaleString('id-ID')}
+                    {formatCurrency(summary.totalIncome)}
                   </p>
                 </div>
               </CardContent>
@@ -304,10 +338,12 @@ const EvaluateContent: React.FC = () => {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <BarChart3 className="w-4 h-4 text-red-500 flex-shrink-0" />
-                    <span className="text-sm text-gray-400">{t('transactions.expense', 'Expenses')}</span>
+                    <span className="text-sm text-gray-400">
+                      {t('transactions.expense', 'Expenses')}
+                    </span>
                   </div>
                   <p className="text-base font-bold text-red-500">
-                    Rp{summary.totalExpenses.toLocaleString('id-ID')}
+                    {formatCurrency(summary.totalExpenses)}
                   </p>
                 </div>
               </CardContent>
@@ -322,8 +358,10 @@ const EvaluateContent: React.FC = () => {
                     <DollarSign className="w-4 h-4 text-blue-500 flex-shrink-0" />
                     <span className="text-sm text-gray-400">{t('ai.netFlow', 'Net Flow')}</span>
                   </div>
-                  <p className={`text-base font-bold ${summary.netFlow >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-                    Rp{summary.netFlow.toLocaleString('id-ID')}
+                  <p
+                    className={`text-base font-bold ${summary.netFlow >= 0 ? 'text-green-500' : 'text-red-500'}`}
+                  >
+                    {formatCurrency(summary.netFlow)}
                   </p>
                 </div>
               </CardContent>
@@ -341,8 +379,7 @@ const EvaluateContent: React.FC = () => {
                   <p className="text-base font-bold text-yellow-500">
                     {summary.totalIncome > 0
                       ? `${((summary.netFlow / summary.totalIncome) * 100).toFixed(1)}%`
-                      : '0%'
-                    }
+                      : '0%'}
                   </p>
                 </div>
               </CardContent>
@@ -351,21 +388,18 @@ const EvaluateContent: React.FC = () => {
         </motion.div>
       )}
 
-      {/* AI Insight Display */}
       {(insight || isLoading) && (
         <motion.div variants={itemVariants}>
           <InsightDisplay text={insight} isLoading={isLoading} />
         </motion.div>
       )}
 
-      {/* Suggested Questions */}
       {insight && currentSummary && (
         <motion.div variants={itemVariants}>
           <SuggestedQuestions onSelect={handleQuestionSelect} />
         </motion.div>
       )}
 
-      {/* Chat Box */}
       {insight && currentSummary && (
         <motion.div variants={itemVariants}>
           <ChatBox
@@ -378,7 +412,7 @@ const EvaluateContent: React.FC = () => {
         </motion.div>
       )}
     </motion.div>
-  );
-};
+  )
+}
 
-export default EvaluateContent;
+export default EvaluateContent

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -192,7 +192,8 @@
     "logout": "Log Out",
     "home": "Home",
     "statistics": "Statistics",
-    "budget": "Budget"
+    "budget": "Budget",
+    "profile": "Profile"
   },
   "dashboard": {
     "title": "Financial Overview",
@@ -516,7 +517,15 @@
     "total": "TOTAL",
     "incomeBreakdown": "Income Breakdown",
     "expenseBreakdown": "Expense Breakdown",
-    "noData": "No data available for the selected period"
+    "noData": "No data available for the selected period",
+    "sixMonthTrend": "Last 6 months",
+    "trendIncome": "Income",
+    "trendExpense": "Expenses",
+    "chartSummary": "Category breakdown for {{range}}. Total {{total}}.",
+    "breakdownTableCaption": "Category breakdown for the chart",
+    "categoryColumn": "Category",
+    "amountColumn": "Amount",
+    "percentColumn": "Share"
   },
   "buttons": {
     "save": "Save",

--- a/src/locales/id.json
+++ b/src/locales/id.json
@@ -190,7 +190,8 @@
     "logout": "Keluar",
     "home": "Beranda",
     "statistics": "Statistik",
-    "budget": "Anggaran"
+    "budget": "Anggaran",
+    "profile": "Profil"
   },
   "dashboard": {
     "title": "Ikhtisar Keuangan",
@@ -516,7 +517,15 @@
     "total": "TOTAL",
     "incomeBreakdown": "Rincian Pemasukan",
     "expenseBreakdown": "Rincian Pengeluaran",
-    "noData": "Tidak ada data untuk periode yang dipilih"
+    "noData": "Tidak ada data untuk periode yang dipilih",
+    "sixMonthTrend": "6 bulan terakhir",
+    "trendIncome": "Pemasukan",
+    "trendExpense": "Pengeluaran",
+    "chartSummary": "Rincian kategori untuk {{range}}. Total {{total}}.",
+    "breakdownTableCaption": "Rincian kategori untuk grafik",
+    "categoryColumn": "Kategori",
+    "amountColumn": "Jumlah",
+    "percentColumn": "Porsi"
   },
   "buttons": {
     "save": "Simpan",

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,262 +1,372 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useFinance } from '@/context/FinanceContext';
-import { ChevronLeft, ChevronDown } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { useCategories } from '@/hooks/useCategories';
-import { Pie } from 'react-chartjs-2';
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
-import { useTransactions } from '@/hooks/useTransactions';
-
-ChartJS.register(ArcElement, Tooltip, Legend);
-import { 
+import React, { useLayoutEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useFinance } from '@/context/FinanceContext'
+import { ChevronLeft, ChevronDown } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { useCategories } from '@/hooks/useCategories'
+import { Pie, Bar } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+} from 'chart.js'
+import { useTransactions } from '@/hooks/useTransactions'
+import {
+  AnalyticsPeriodProvider,
+  useAnalyticsPeriod,
+} from '@/context/AnalyticsPeriodContext'
+import {
   Popover,
   PopoverContent,
-  PopoverTrigger
-} from "@/components/ui/popover";
-import { Button } from "@/components/ui/button";
-import { Calendar } from "@/components/ui/calendar";
-import { format } from "date-fns";
-import { motion, AnimatePresence } from 'framer-motion';
-import { Transaction } from '@/types/finance';
-import EvaluateContent from '@/features/ai-evaluator/EvaluateContent';
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { format } from 'date-fns'
+import { motion } from 'framer-motion'
+import { Transaction } from '@/types/finance'
+import type { Category } from '@/types/category'
+import EvaluateContent from '@/features/ai-evaluator/EvaluateContent'
 
-type TabType = 'income' | 'outcome' | 'analysis';
+ChartJS.register(
+  ArcElement,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+)
 
-// Define interface for grouped category data
+type TabType = 'income' | 'outcome' | 'analysis'
+
 interface CategoryTotal {
-  total: number;
-  categoryId: string | null;
-  displayName: string;
+  total: number
+  categoryId: string | null
+  displayName: string
 }
 
-// Chart data format
 interface ChartDataItem {
-  name: string;
-  value: number;
-  percentage: number;
-  categoryId: string | null;
+  name: string
+  value: number
+  percentage: number
+  categoryId: string | null
 }
 
-// Function to group transactions by categoryId
 function groupTransactionsByCategory(
   transactions: Transaction[],
-  t: any,
-  findById: (id: number) => any,
-  getDisplayName: (category: any) => string
+  t: (key: string) => string,
+  findById: (id: number) => Category | undefined,
+  getDisplayName: (category: Category) => string,
 ): CategoryTotal[] {
-  const categoryTotals: Record<string, CategoryTotal> = {};
-  
-  transactions.forEach(transaction => {
-    // Get the display name for the category
-    let categoryName: string;
+  const categoryTotals: Record<string, CategoryTotal> = {}
+
+  transactions.forEach((transaction) => {
+    let categoryName: string
     if (transaction.type === 'transfer') {
-      categoryName = t('transactions.transfer');
+      categoryName = t('transactions.transfer')
     } else if (transaction.categoryId && findById(transaction.categoryId)) {
-      categoryName = getDisplayName(findById(transaction.categoryId)!);
+      categoryName = getDisplayName(findById(transaction.categoryId)!)
     } else {
-      categoryName = t('transactions.uncategorized');
+      categoryName = t('transactions.uncategorized')
     }
-    
-    // Use the categoryName as the key
-    const key = categoryName;
-    
-    // Initialize if this is the first transaction for this category
+
+    const key = categoryName
+
     if (!categoryTotals[key]) {
       categoryTotals[key] = {
         total: 0,
-        categoryId: transaction.categoryId?.toString() || null,
-        displayName: categoryName
-      };
-    }
-    
-    // Add the amount to the total
-    categoryTotals[key].total += transaction.amount;
-  });
-  
-  return Object.values(categoryTotals);
-}
-
-const Statistics: React.FC = () => {
-  const { t } = useTranslation();
-  const { transactions, formatCurrency } = useFinance();
-  const { findById, getDisplayName } = useCategories();
-  
-  // State for date selection
-  const [dateRange, setDateRange] = useState<'7days' | '30days' | 'month' | 'custom'>('month');
-  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
-  const [customStartDate, setCustomStartDate] = useState<Date | undefined>(undefined);
-  const [customEndDate, setCustomEndDate] = useState<Date | undefined>(undefined);
-  
-  // Currently selected tab
-  const [activeTab, setActiveTab] = useState<TabType>('outcome');
-  
-  // Current month and year for display
-  const currentDate = new Date();
-  const currentMonthYear = format(currentDate, 'MMMM yyyy');
-  
-  // Filter transactions based on selected date range and tab
-  const getFilteredTransactions = () => {
-    const now = new Date();
-    let startDate: Date;
-    
-    // Determine start date based on selected range
-    if (dateRange === '7days') {
-      startDate = new Date(now);
-      startDate.setDate(now.getDate() - 7);
-    } else if (dateRange === '30days') {
-      startDate = new Date(now);
-      startDate.setDate(now.getDate() - 30);
-    } else if (dateRange === 'month') {
-      startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-    } else if (dateRange === 'custom' && customStartDate && customEndDate) {
-      startDate = customStartDate;
-      // For custom range, use the selected end date instead of now
-      now.setHours(23, 59, 59, 999); // End of day
-      now.setTime(customEndDate.getTime());
-    } else {
-      // Default to current month
-      startDate = new Date(now.getFullYear(), now.getMonth(), 1);
-    }
-    
-    // Filter transactions by date and type
-    return transactions.filter(transaction => {
-      const transactionDate = new Date(transaction.date);
-      return (
-        transactionDate >= startDate && 
-        transactionDate <= now &&
-        transaction.type === (activeTab === 'income' ? 'income' : 'expense')
-      );
-    });
-  };
-  
-  const filteredTransactions = getFilteredTransactions();
-  
-  // Calculate total for current filter
-  const totalAmount = filteredTransactions.reduce((sum, t) => sum + t.amount, 0);
-  
-  // Group transactions by category with new category system
-  const groupedCategories = groupTransactionsByCategory(filteredTransactions, t, findById, getDisplayName);
-  
-  // Convert to chart data format and calculate percentages
-  const chartData: ChartDataItem[] = groupedCategories.map(category => {
-    const percentage = totalAmount > 0 ? Math.round((category.total / totalAmount) * 100) : 0;
-    return {
-      name: category.displayName,
-      value: category.total,
-      percentage: percentage,
-      categoryId: category.categoryId
-    };
-  });
-  
-  // Sort data by value in descending order for better display
-  chartData.sort((a, b) => b.value - a.value);
-  
-  // Colors for pie chart - using a varied yet harmonious color palette
-  const COLORS = useMemo(() => ['#8B5CF6', '#EC4899', '#F59E0B', '#10B981', '#3B82F6', '#14B8A6', '#6366F1', '#F43F5E', '#84CC16', '#06B6D4'], []);
-
-  // Prepare Chart.js data structure
-  const pieChartData = useMemo(() => ({
-    labels: chartData.map(item => item.name),
-    datasets: [{
-      data: chartData.map(item => item.value),
-      backgroundColor: chartData.map((_, index) => COLORS[index % COLORS.length]),
-      borderWidth: 0,
-      borderRadius: 8,
-    }]
-  }), [chartData, COLORS]);
-
-  // Chart.js options
-  const chartOptions = useMemo(() => ({
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        display: false,
-      },
-      tooltip: {
-        backgroundColor: '#1A1A1A',
-        titleColor: '#fff',
-        bodyColor: '#fff',
-        borderColor: '#333',
-        borderWidth: 1,
-        padding: 12,
-        titleFont: { size: 12, weight: 'bold' },
-        bodyFont: { size: 12 },
-        callbacks: {
-          label: (context: any) => formatCurrency(context.parsed),
-        }
+        categoryId: transaction.categoryId?.toString() ?? null,
+        displayName: categoryName,
       }
     }
-  }), [formatCurrency]);
-  
+
+    categoryTotals[key].total += transaction.amount
+  })
+
+  return Object.values(categoryTotals)
+}
+
+function hslFromVar(raw: string, fallback: string): string {
+  const v = raw.trim()
+  if (!v) return fallback
+  if (v.startsWith('#')) return v
+  return `hsl(${v})`
+}
+
+function StatisticsInner() {
+  const { t } = useTranslation()
+  const { transactions, formatCurrency } = useFinance()
+  const { findById, getDisplayName } = useCategories()
+  const { monthlyData } = useTransactions()
+  const {
+    preset: dateRange,
+    setPreset: setDateRange,
+    customStartDate,
+    customEndDate,
+    setCustomRange,
+    periodStart,
+    periodEnd,
+  } = useAnalyticsPeriod()
+
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState<TabType>('outcome')
+
+  const [chartTheme, setChartTheme] = useState({
+    tooltipBg: 'hsl(0 0% 10%)',
+    tooltipFg: 'hsl(0 0% 100%)',
+    tooltipBorder: 'hsl(0 0% 20%)',
+    incomeBar: 'hsl(142 76% 45%)',
+    expenseBar: 'hsl(0 84% 55%)',
+  })
+
+  useLayoutEffect(() => {
+    const root = document.documentElement
+    const cs = getComputedStyle(root)
+    setChartTheme({
+      tooltipBg: hslFromVar(cs.getPropertyValue('--popover'), 'hsl(0 0% 10%)'),
+      tooltipFg: hslFromVar(
+        cs.getPropertyValue('--popover-foreground'),
+        'hsl(0 0% 100%)',
+      ),
+      tooltipBorder: hslFromVar(cs.getPropertyValue('--border'), 'hsl(0 0% 20%)'),
+      incomeBar: hslFromVar(cs.getPropertyValue('--finance-income'), 'hsl(142 76% 45%)'),
+      expenseBar: hslFromVar(cs.getPropertyValue('--finance-expense'), 'hsl(0 84% 55%)'),
+    })
+  }, [])
+
+  const currentDate = new Date()
+  const currentMonthYear = format(currentDate, 'MMMM yyyy')
+
+  const filteredTransactions = useMemo(() => {
+    return transactions.filter((transaction) => {
+      const transactionDate = new Date(transaction.date)
+      return (
+        transactionDate >= periodStart &&
+        transactionDate <= periodEnd &&
+        transaction.type === (activeTab === 'income' ? 'income' : 'expense')
+      )
+    })
+  }, [transactions, periodStart, periodEnd, activeTab])
+
+  const totalAmount = filteredTransactions.reduce((sum, tr) => sum + tr.amount, 0)
+
+  const groupedCategories = useMemo(
+    () =>
+      groupTransactionsByCategory(filteredTransactions, t, findById, getDisplayName),
+    [filteredTransactions, t, findById, getDisplayName],
+  )
+
+  const chartData: ChartDataItem[] = useMemo(() => {
+    const rows = groupedCategories.map((category) => {
+      const percentage =
+        totalAmount > 0 ? Math.round((category.total / totalAmount) * 100) : 0
+      return {
+        name: category.displayName,
+        value: category.total,
+        percentage,
+        categoryId: category.categoryId,
+      }
+    })
+    rows.sort((a, b) => b.value - a.value)
+    return rows
+  }, [groupedCategories, totalAmount])
+
+  const COLORS = useMemo(
+    () => [
+      '#8B5CF6',
+      '#EC4899',
+      '#F59E0B',
+      '#10B981',
+      '#3B82F6',
+      '#14B8A6',
+      '#6366F1',
+      '#F43F5E',
+      '#84CC16',
+      '#06B6D4',
+    ],
+    [],
+  )
+
+  const pieChartData = useMemo(
+    () => ({
+      labels: chartData.map((item) => item.name),
+      datasets: [
+        {
+          data: chartData.map((item) => item.value),
+          backgroundColor: chartData.map((_, index) => COLORS[index % COLORS.length]),
+          borderWidth: 0,
+          borderRadius: 8,
+        },
+      ],
+    }),
+    [chartData, COLORS],
+  )
+
+  const chartOptions = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: false,
+        },
+        tooltip: {
+          backgroundColor: chartTheme.tooltipBg,
+          titleColor: chartTheme.tooltipFg,
+          bodyColor: chartTheme.tooltipFg,
+          borderColor: chartTheme.tooltipBorder,
+          borderWidth: 1,
+          padding: 12,
+          titleFont: { size: 12, weight: 'bold' as const },
+          bodyFont: { size: 12 },
+          callbacks: {
+            label: (context: { parsed: number }) => formatCurrency(context.parsed),
+          },
+        },
+      },
+    }),
+    [formatCurrency, chartTheme],
+  )
+
+  const barChartData = useMemo(
+    () => ({
+      labels: monthlyData.map((m) => m.month),
+      datasets: [
+        {
+          label: t('statistics.trendIncome'),
+          data: monthlyData.map((m) => m.income),
+          backgroundColor: chartTheme.incomeBar,
+          borderRadius: 6,
+        },
+        {
+          label: t('statistics.trendExpense'),
+          data: monthlyData.map((m) => m.expense),
+          backgroundColor: chartTheme.expenseBar,
+          borderRadius: 6,
+        },
+      ],
+    }),
+    [monthlyData, t, chartTheme],
+  )
+
+  const barChartOptions = useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: true,
+          labels: { color: chartTheme.tooltipFg },
+        },
+        tooltip: {
+          backgroundColor: chartTheme.tooltipBg,
+          titleColor: chartTheme.tooltipFg,
+          bodyColor: chartTheme.tooltipFg,
+          borderColor: chartTheme.tooltipBorder,
+          borderWidth: 1,
+          callbacks: {
+            label: (ctx: {
+              dataset: { label?: string }
+              parsed: number | { x?: string; y: number }
+            }) => {
+              const raw = ctx.parsed
+              const v = typeof raw === 'number' ? raw : raw.y
+              return `${ctx.dataset.label ?? ''}: ${formatCurrency(v)}`
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          ticks: { color: chartTheme.tooltipFg },
+          grid: { color: chartTheme.tooltipBorder },
+        },
+        y: {
+          ticks: { color: chartTheme.tooltipFg },
+          grid: { color: chartTheme.tooltipBorder },
+        },
+      },
+    }),
+    [formatCurrency, chartTheme],
+  )
+
+  const pieSummaryCaption = useMemo(() => {
+    const rangeLabel =
+      dateRange === 'month'
+        ? currentMonthYear
+        : `${format(periodStart, 'MMM d, yyyy')} – ${format(periodEnd, 'MMM d, yyyy')}`
+    return t('statistics.chartSummary', {
+      range: rangeLabel,
+      total: formatCurrency(totalAmount),
+    })
+  }, [dateRange, currentMonthYear, periodStart, periodEnd, t, formatCurrency, totalAmount])
+
   const handleTabChange = (tab: TabType) => {
-    setActiveTab(tab);
-  };
-  
+    setActiveTab(tab)
+  }
+
   const getDateRangeLabel = () => {
     switch (dateRange) {
       case '7days':
-        return t('statistics.last7Days');
+        return t('statistics.last7Days')
       case '30days':
-        return t('statistics.last30Days');
+        return t('statistics.last30Days')
       case 'month':
-        return currentMonthYear;
+        return currentMonthYear
       case 'custom':
         if (customStartDate && customEndDate) {
-          return `${format(customStartDate, 'MMM d')} - ${format(customEndDate, 'MMM d, yyyy')}`;
+          return `${format(customStartDate, 'MMM d')} - ${format(customEndDate, 'MMM d, yyyy')}`
         }
-        return t('statistics.customRange');
+        return t('statistics.customRange')
       default:
-        return currentMonthYear;
+        return currentMonthYear
     }
-  };
+  }
 
-  // Animation variants
   const containerVariants = {
     hidden: { opacity: 0 },
     visible: {
       opacity: 1,
       transition: {
-        when: "beforeChildren",
-        staggerChildren: 0.1
-      }
-    }
-  };
+        when: 'beforeChildren' as const,
+        staggerChildren: 0.1,
+      },
+    },
+  }
 
   const itemVariants = {
     hidden: { y: 20, opacity: 0 },
     visible: {
       y: 0,
       opacity: 1,
-      transition: { type: "spring", stiffness: 300, damping: 24 }
-    }
-  };
+      transition: { type: 'spring' as const, stiffness: 300, damping: 24 },
+    },
+  }
 
   return (
-    <motion.div 
+    <motion.div
       className="max-w-md mx-auto bg-[#0D0D0D] min-h-screen pb-24 text-white px-0"
       initial="hidden"
       animate="visible"
       variants={containerVariants}
     >
       <div className="p-6 pt-12">
-        {/* Header */}
-        <motion.div 
-          className="mb-6 flex items-center justify-between"
-          variants={itemVariants}
-        >
+        <motion.div className="mb-6 flex items-center justify-between" variants={itemVariants}>
           <div className="flex items-center">
             <Link to="/" className="mr-4 text-white">
               <ChevronLeft size={24} />
             </Link>
             <h1 className="text-xl font-bold">{t('statistics.title')}</h1>
           </div>
-          
+
           <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
             <PopoverTrigger asChild>
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 className="flex items-center gap-2 rounded-full text-sm font-normal bg-[#242425] border-0 text-white hover:bg-[#333]"
               >
                 {getDateRangeLabel()}
@@ -266,65 +376,87 @@ const Statistics: React.FC = () => {
             <PopoverContent className="w-auto p-4 bg-[#242425] border-0 text-white" align="end">
               <div className="space-y-4">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  <Button 
-                    variant={dateRange === '7days' ? 'default' : 'outline'} 
-                    className={dateRange === '7days' ? 'bg-[#C6FE1E] text-[#0D0D0D]' : 'bg-[#1A1A1A] text-white border-0'}
+                  <Button
+                    variant={dateRange === '7days' ? 'default' : 'outline'}
+                    className={
+                      dateRange === '7days'
+                        ? 'bg-[#C6FE1E] text-[#0D0D0D]'
+                        : 'bg-[#1A1A1A] text-white border-0'
+                    }
                     onClick={() => {
-                      setDateRange('7days');
-                      setIsCalendarOpen(false);
+                      setDateRange('7days')
+                      setIsCalendarOpen(false)
                     }}
                   >
                     {t('statistics.last7Days')}
                   </Button>
-                  <Button 
-                    variant={dateRange === '30days' ? 'default' : 'outline'} 
-                    className={dateRange === '30days' ? 'bg-[#C6FE1E] text-[#0D0D0D]' : 'bg-[#1A1A1A] text-white border-0'}
+                  <Button
+                    variant={dateRange === '30days' ? 'default' : 'outline'}
+                    className={
+                      dateRange === '30days'
+                        ? 'bg-[#C6FE1E] text-[#0D0D0D]'
+                        : 'bg-[#1A1A1A] text-white border-0'
+                    }
                     onClick={() => {
-                      setDateRange('30days');
-                      setIsCalendarOpen(false);
+                      setDateRange('30days')
+                      setIsCalendarOpen(false)
                     }}
                   >
                     {t('statistics.last30Days')}
                   </Button>
-                  <Button 
-                    variant={dateRange === 'month' ? 'default' : 'outline'} 
-                    className={dateRange === 'month' ? 'bg-[#C6FE1E] text-[#0D0D0D]' : 'bg-[#1A1A1A] text-white border-0'}
+                  <Button
+                    variant={dateRange === 'month' ? 'default' : 'outline'}
+                    className={
+                      dateRange === 'month'
+                        ? 'bg-[#C6FE1E] text-[#0D0D0D]'
+                        : 'bg-[#1A1A1A] text-white border-0'
+                    }
                     onClick={() => {
-                      setDateRange('month');
-                      setIsCalendarOpen(false);
+                      setDateRange('month')
+                      setIsCalendarOpen(false)
                     }}
                   >
                     {t('statistics.thisMonth')}
                   </Button>
-                  <Button 
-                    variant={dateRange === 'custom' ? 'default' : 'outline'} 
-                    className={dateRange === 'custom' ? 'bg-[#C6FE1E] text-[#0D0D0D]' : 'bg-[#1A1A1A] text-white border-0'}
+                  <Button
+                    variant={dateRange === 'custom' ? 'default' : 'outline'}
+                    className={
+                      dateRange === 'custom'
+                        ? 'bg-[#C6FE1E] text-[#0D0D0D]'
+                        : 'bg-[#1A1A1A] text-white border-0'
+                    }
                     onClick={() => {
-                      setDateRange('custom');
+                      setDateRange('custom')
                       if (!customStartDate || !customEndDate) {
-                        const today = new Date();
-                        setCustomStartDate(new Date(today.getFullYear(), today.getMonth(), 1));
-                        setCustomEndDate(today);
+                        const today = new Date()
+                        setCustomRange(
+                          new Date(today.getFullYear(), today.getMonth(), 1),
+                          today,
+                        )
                       }
                     }}
                   >
                     {t('statistics.customRange')}
                   </Button>
                 </div>
-                
+
                 {dateRange === 'custom' && (
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-xs text-[#868686] mb-1">{t('statistics.startDate')}</p>
-                        <p className="text-sm">{customStartDate ? format(customStartDate, 'MMM d, yyyy') : '-'}</p>
+                        <p className="text-sm">
+                          {customStartDate ? format(customStartDate, 'MMM d, yyyy') : '-'}
+                        </p>
                       </div>
                       <div>
                         <p className="text-xs text-[#868686] mb-1">{t('statistics.endDate')}</p>
-                        <p className="text-sm">{customEndDate ? format(customEndDate, 'MMM d, yyyy') : '-'}</p>
+                        <p className="text-sm">
+                          {customEndDate ? format(customEndDate, 'MMM d, yyyy') : '-'}
+                        </p>
                       </div>
                     </div>
-                    
+
                     <Calendar
                       mode="range"
                       selected={{
@@ -332,13 +464,12 @@ const Statistics: React.FC = () => {
                         to: customEndDate,
                       }}
                       onSelect={(range) => {
-                        setCustomStartDate(range?.from);
-                        setCustomEndDate(range?.to);
+                        setCustomRange(range?.from, range?.to)
                       }}
                       className="rounded-md border-0 bg-[#1A1A1A]"
                     />
-                    
-                    <Button 
+
+                    <Button
                       className="w-full bg-[#C6FE1E] text-[#0D0D0D] hover:bg-[#B0E018] font-medium"
                       onClick={() => setIsCalendarOpen(false)}
                     >
@@ -350,14 +481,11 @@ const Statistics: React.FC = () => {
             </PopoverContent>
           </Popover>
         </motion.div>
-        
-        {/* Tab buttons for Income/Expense/Analysis */}
-        <motion.div 
-          className="mb-6"
-          variants={itemVariants}
-        >
+
+        <motion.div className="mb-6" variants={itemVariants}>
           <div className="flex bg-[#242425] rounded-full p-1">
             <motion.button
+              type="button"
               className={`flex-1 py-2 text-center rounded-full text-sm ${activeTab === 'outcome' ? 'bg-[#C6FE1E] text-[#0D0D0D] font-medium' : 'text-white'}`}
               onClick={() => handleTabChange('outcome')}
               whileTap={{ scale: 0.98 }}
@@ -365,6 +493,7 @@ const Statistics: React.FC = () => {
               {t('statistics.expense')}
             </motion.button>
             <motion.button
+              type="button"
               className={`flex-1 py-2 text-center rounded-full text-sm ${activeTab === 'income' ? 'bg-[#C6FE1E] text-[#0D0D0D] font-medium' : 'text-white'}`}
               onClick={() => handleTabChange('income')}
               whileTap={{ scale: 0.98 }}
@@ -372,6 +501,7 @@ const Statistics: React.FC = () => {
               {t('statistics.income')}
             </motion.button>
             <motion.button
+              type="button"
               className={`flex-1 py-2 text-center rounded-full text-sm ${activeTab === 'analysis' ? 'bg-[#C6FE1E] text-[#0D0D0D] font-medium' : 'text-white'}`}
               onClick={() => handleTabChange('analysis')}
               whileTap={{ scale: 0.98 }}
@@ -380,48 +510,68 @@ const Statistics: React.FC = () => {
             </motion.button>
           </div>
         </motion.div>
-        
-        {/* Content Section */}
+
         {activeTab === 'analysis' ? (
-          <motion.div 
-            className="-mx-6 -mb-6"
-            variants={itemVariants}
-          >
+          <motion.div className="-mx-6 -mb-6" variants={itemVariants}>
             <EvaluateContent />
           </motion.div>
         ) : filteredTransactions.length > 0 ? (
           <>
-            {/* Chart Section - Using Chart.js */}
-            <div className="mb-8 border bg-card p-6 rounded-xl">
-              <div className="h-[280px] w-full relative">
-                <Pie 
-                  data={pieChartData} 
-                  options={chartOptions}
-                />
-                
-                {/* Center Text */}
-                <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center pointer-events-none">
-                  <p className="text-[#868686] text-sm">{t('statistics.total')}</p>
-                  <p className="text-xl font-bold">{formatCurrency(totalAmount)}</p>
-                </div>
+            <div className="mb-6 border bg-card p-6 rounded-xl">
+              <h3 className="text-sm font-semibold text-muted-foreground mb-3">
+                {t('statistics.sixMonthTrend')}
+              </h3>
+              <div className="h-[220px] w-full relative">
+                <Bar data={barChartData} options={barChartOptions} />
               </div>
             </div>
-            
-            <motion.div 
-              className="mt-8" 
-              variants={itemVariants}
-            >
+
+            <div className="mb-8 border bg-card p-6 rounded-xl">
+              <figure className="relative">
+                <figcaption className="sr-only">{pieSummaryCaption}</figcaption>
+                <div className="h-[280px] w-full relative">
+                  <Pie data={pieChartData} options={chartOptions} />
+                  <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center pointer-events-none">
+                    <p className="text-[#868686] text-sm">{t('statistics.total')}</p>
+                    <p className="text-xl font-bold">{formatCurrency(totalAmount)}</p>
+                  </div>
+                </div>
+              </figure>
+              <table className="sr-only">
+                <caption>{t('statistics.breakdownTableCaption')}</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">{t('statistics.categoryColumn')}</th>
+                    <th scope="col">{t('statistics.amountColumn')}</th>
+                    <th scope="col">{t('statistics.percentColumn')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {chartData.map((row) => (
+                    <tr key={`${row.name}-${row.categoryId ?? 'x'}`}>
+                      <td>{row.name}</td>
+                      <td>{formatCurrency(row.value)}</td>
+                      <td>{row.percentage}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <motion.div className="mt-8" variants={itemVariants}>
               <h3 className="text-lg font-bold mb-4">
-                {activeTab === 'income' ? t('statistics.incomeBreakdown') : t('statistics.expenseBreakdown')}
+                {activeTab === 'income'
+                  ? t('statistics.incomeBreakdown')
+                  : t('statistics.expenseBreakdown')}
               </h3>
               <div className="space-y-3">
                 {chartData.map((category, index) => (
-                  <motion.div 
+                  <motion.div
                     key={`${category.name}-${index}`}
                     className="flex justify-between items-center p-4 border bg-card rounded-xl"
                     initial={{ opacity: 0, x: -10 }}
                     animate={{ opacity: 1, x: 0 }}
-                    transition={{ delay: 0.2 + (index * 0.05) }}
+                    transition={{ delay: 0.2 + index * 0.05 }}
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}
                   >
@@ -430,9 +580,12 @@ const Statistics: React.FC = () => {
                     </div>
                     <div className="flex items-center gap-3">
                       <span className="font-medium">{formatCurrency(category.value)}</span>
-                      <div className="px-2 py-1 rounded-full text-xs font-medium text-white" style={{ 
-                        backgroundColor: COLORS[index % COLORS.length]
-                      }}>
+                      <div
+                        className="px-2 py-1 rounded-full text-xs font-medium text-white"
+                        style={{
+                          backgroundColor: COLORS[index % COLORS.length],
+                        }}
+                      >
                         {category.percentage}%
                       </div>
                     </div>
@@ -442,7 +595,7 @@ const Statistics: React.FC = () => {
             </motion.div>
           </>
         ) : (
-          <motion.div 
+          <motion.div
             className="h-[250px] flex items-center justify-center bg-[#242425] rounded-xl"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -453,7 +606,13 @@ const Statistics: React.FC = () => {
         )}
       </div>
     </motion.div>
-  );
-};
+  )
+}
 
-export default Statistics;
+const Statistics: React.FC = () => (
+  <AnalyticsPeriodProvider>
+    <StatisticsInner />
+  </AnalyticsPeriodProvider>
+)
+
+export default Statistics


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the high–medium priority analytics plan using **Approach B** (shared context for the reporting period on Statistics).

### High
- **`AnalyticsPeriodProvider`** wraps the Statistics page. `periodStart` / `periodEnd` come from `computeAnalyticsBounds` with **immutable** date handling (fixes the previous `now.setTime` mutation bug).
- **`EvaluateContent`** uses `formatCurrency` from `useFinance` for quick stats (no hardcoded `Rp`).
- **Chart accessibility**: `figcaption` (sr-only) + **sr-only table** mirroring pie breakdown for screen readers.

### Medium
- **Six-month trend**: grouped bar chart (income vs expense) using existing `useTransactions().monthlyData`.
- **Period sync**: `EvaluateContent` reads `useOptionalAnalyticsPeriod()`; changing Analysis dates calls `setPeriodFromAnalysis` so the header popover stays on **custom** with the same range.
- **Theme-aware charts**: tooltip and bar colors read CSS variables (`--popover`, `--border`, `--finance-income`, `--finance-expense`) via `getComputedStyle` in a layout effect.
- **Navbar i18n**: bottom nav labels use `t('navbar.*')`; added `navbar.profile`.

### Files
- `src/context/analyticsPeriodUtils.ts` – pure `computeAnalyticsBounds`
- `src/context/AnalyticsPeriodContext.tsx` – provider + hooks
- `src/pages/Statistics.tsx` – provider wrapper, context-driven filtering, bar + pie, a11y
- `src/features/ai-evaluator/EvaluateContent.tsx` – optional context + currency
- `src/components/layout/Navbar.tsx`, `src/locales/en.json`, `src/locales/id.json`

### Verification
- `npm run build` passes.
- Full `vitest run` has pre-existing failures in the repo; targeted eslint on changed files passes (two react-refresh warnings on non-component exports in the context file).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4a0973a-c714-4f30-8082-afeef6a76630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4a0973a-c714-4f30-8082-afeef6a76630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

